### PR TITLE
Notify on execution error

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,13 @@ function logTestSuite(suite) {
 
     console.log("##teamcity[testSuiteStarted name='%s']", name);
 
-    suite.testResults.forEach(it => logTestResult(suite, it));
+    if (suite.failureMessage) {
+        console.log("##teamcity[testStarted name='Execution Error']");
+        console.log("##teamcity[testFailed name='Execution Error' message='FAILED' details='%s']", escape(suite.failureMessage));
+        console.log("##teamcitytestFinished name='Execution Error' duration='0']");
+    } else {
+        suite.testResults.forEach(it => logTestResult(suite, it));
+    }
 
     console.log("##teamcity[testSuiteFinished name='%s' duration='%s']", name, duration);
 }


### PR DESCRIPTION
Hey there, I pulled this into our codebase today and found when an entire test suite failed to execute no message was created.

I'm not sure if you have a better way to determine if the entire suite failed because I wasn't able to find a type definition for the test suite failures from jest.