### PR TITLE
Show full test path relative to project root directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
-var pathSep = require('path').sep;
+var path = require('path');
 var TEAMCITY_VERSION = 'TEAMCITY_VERSION';
 
 function teamcityReporter(result) {
+    const appDir = path.resolve(__dirname).split('/node_modules')[0];
+
     if (TEAMCITY_VERSION in process.env) {
         result.testResults.forEach(it => logTestSuite(it));
     }
@@ -9,8 +11,8 @@ function teamcityReporter(result) {
 }
 
 function logTestSuite(suite) {
-    const split = suite.testFilePath.split(pathSep);
-    const name = escape(split[split.length - 2] + '/' + split[split.length - 1]);
+    const testFilePath = path.relative(appDir, suite.testFilePath);
+    const name = escape(testFilePath);
     const duration = suite.perfStats.end - suite.perfStats.start;
     const testResults = suite.testResults;
 

--- a/index.js
+++ b/index.js
@@ -5,12 +5,12 @@ function teamcityReporter(result) {
     const appDir = path.resolve(__dirname).split('/node_modules')[0];
 
     if (TEAMCITY_VERSION in process.env) {
-        result.testResults.forEach(it => logTestSuite(it));
+        result.testResults.forEach(it => logTestSuite(appDir, it));
     }
     return result;
 }
 
-function logTestSuite(suite) {
+function logTestSuite(appDir, suite) {
     const testFilePath = path.relative(appDir, suite.testFilePath);
     const name = escape(testFilePath);
     const duration = suite.perfStats.end - suite.perfStats.start;


### PR DESCRIPTION
Currently only test file name and containing folder are shown which creates issues when tests are placed in folders like `tests`, `__tests__`, etc.

This PR changes that behaviour and full paths (relative to project directory) will be shown.

Before:
```
##teamcity[testSuiteStarted name='tests/reducer.test.js']
...
##teamcity[testSuiteStarted name='tests/reducer.test.js']
...
```
After:
```
##teamcity[testSuiteStarted name='containers/one/tests/reducer.test.js']
...
##teamcity[testSuiteStarted name='containers/two/tests/reducer.test.js']
...
```
