### PR TITLE
Show full name of tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function logTestSuite(suite) {
 }
 
 function logTestResult(suite, testResult) {
-    const name = escape(testResult.title);
+    const name = escape(testResult.fullName);
     const duration = testResult.duration;
 
     console.log("##teamcity[testStarted name='%s']", name);


### PR DESCRIPTION
The easiest way to resolve issue https://github.com/winterbe/jest-teamcity-reporter/issues/8#issue-200432764

Full name also contains description from `description` block, not only from `it` block. It allows TeamCity to separate equal-named tests in one file.