### PR TITLE
Report jest coverage data as TeamCity build statistics

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var TEAMCITY_VERSION = 'TEAMCITY_VERSION';
 function teamcityReporter(result) {
     if (TEAMCITY_VERSION in process.env) {
         result.testResults.forEach(it => logTestSuite(it));
+        logCoverage(result.coverageMap);
     }
     return result;
 }
@@ -41,10 +42,25 @@ function logTestResult(suite, testResult) {
     }
 
     if (testResult.status === 'pending' || testResult.status === 'skipped') {
-      console.log("##teamcity[testIgnored name='%s' message='%s']", name, testResult.status);
+        console.log("##teamcity[testIgnored name='%s' message='%s']", name, testResult.status);
     }
 
-  console.log("##teamcity[testFinished name='%s' duration='%s']", name, duration);
+    console.log("##teamcity[testFinished name='%s' duration='%s']", name, duration);
+}
+
+function logCoverage(coverageMap) {
+    const coverageSummary = coverageMap.getCoverageSummary().data;
+    const map = new Map([
+        ['L', coverageSummary.lines],
+        ['S', coverageSummary.statements],
+        ['M', coverageSummary.functions],
+        ['R', coverageSummary.branches]
+    ]);
+    map.forEach((metrics, abbreviation) => {
+        console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoverageAbs${abbr}TotalJS`, metrics.total);
+        console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoverageAbs${abbr}CoveredJS`, metrics.covered);
+        console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoveragePercent${abbr}CoveredJS`, metrics.pct);
+    });
 }
 
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ var TEAMCITY_VERSION = 'TEAMCITY_VERSION';
 function teamcityReporter(result) {
     if (TEAMCITY_VERSION in process.env) {
         result.testResults.forEach(it => logTestSuite(it));
-        logCoverage(result.coverageMap);
+        if (result.coverageMap !== 'undefined') {
+            logCoverage(result.coverageMap);
+        }
     }
     return result;
 }
@@ -49,18 +51,20 @@ function logTestResult(suite, testResult) {
 }
 
 function logCoverage(coverageMap) {
-    const coverageSummary = coverageMap.getCoverageSummary().data;
-    const map = new Map([
-        ['L', coverageSummary.lines],
-        ['S', coverageSummary.statements],
-        ['M', coverageSummary.functions],
-        ['R', coverageSummary.branches]
-    ]);
-    map.forEach((metrics, abbreviation) => {
-        console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoverageAbs${abbr}TotalJS`, metrics.total);
-        console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoverageAbs${abbr}CoveredJS`, metrics.covered);
-        console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoveragePercent${abbr}CoveredJS`, metrics.pct);
-    });
+    if (typeof coverageMap.getCoverageSummary === 'function') {
+        const coverageSummary = coverageMap.getCoverageSummary().data;
+        const map = new Map([
+            ['Lines', coverageSummary.lines],
+            ['Statements', coverageSummary.statements],
+            ['Functions', coverageSummary.functions],
+            ['Branches', coverageSummary.branches]
+        ]);
+        map.forEach((metrics, key) => {
+            console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Total Number of JS ${key}`, metrics.total);
+            console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Covered Number of JS ${key}`, metrics.covered);
+            console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Covered Percentage of JS ${key}`, metrics.pct);
+        });
+    }
 }
 
 


### PR DESCRIPTION
Fixes #18.

If jest is run without the `--coverage` parameter then there is no change to existing behaviour. If the `--coverage` parameter is used then custom build metrics for JavaScript code coverage are reported to TeamCity.