### PR TITLE
Fix Cannot read property 'getCoverageSummary' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var TEAMCITY_VERSION = 'TEAMCITY_VERSION';
 function teamcityReporter(result) {
     if (TEAMCITY_VERSION in process.env) {
         result.testResults.forEach(it => logTestSuite(it));
-        if (result.coverageMap !== 'undefined') {
+        if (result.coverageMap !== null) {
             logCoverage(result.coverageMap);
         }
     }


### PR DESCRIPTION
`result.coverageMap !== 'undefined'` results in `true` when `result.coverageMap` is `null` and call to logCoverage fails with 
```
TypeError: Cannot read property 'getCoverageSummary' of undefined
    at logCoverage (node_modules/jest-teamcity-reporter/index.js:54:27)
    at teamcityReporter (node_modules/jest-teamcity-reporter/index.js:8:13)
    at processResults (node_modules/jest/node_modules/jest-cli/build/runJest.js:126:55)
    at node_modules/jest/node_modules/jest-cli/build/runJest.js:211:12
    at next (native)
    at step (node_modules/jest/node_modules/jest-cli/build/runJest.js:1:260)
    at /Users/lucker/POM/pom-frontend/node_modules/jest/node_modules/jest-cli/build/runJest.js:1:420
```