### PR TITLE
Use TeamCity Default Statistics Values

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,9 +60,20 @@ function logCoverage(coverageMap) {
             ['Branches', coverageSummary.branches]
         ]);
         map.forEach((metrics, key) => {
+            const tcKeyDict = {
+                'Lines': 'L',
+                'Functions': 'M'
+            };
+            
             console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Total Number of JS ${key}`, metrics.total);
             console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Covered Number of JS ${key}`, metrics.covered);
             console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Covered Percentage of JS ${key}`, metrics.pct);
+            
+            if(tcKeyDict[key]) {
+                const tcKey = tcKeyDict[key];
+                console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoverageAbs${tcKey}Total`, metrics.total);
+                console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoverageAbs${tcKey}Covered`, metrics.covered);
+            }
         });
     }
 }

--- a/index.js
+++ b/index.js
@@ -62,7 +62,9 @@ function logCoverage(coverageMap) {
         map.forEach((metrics, key) => {
             const tcKeyDict = {
                 'Lines': 'L',
-                'Functions': 'M'
+                'Functions': 'M',
+                'Branches': 'R',
+                'Statements': 'S'
             };
             
             console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Total Number of JS ${key}`, metrics.total);


### PR DESCRIPTION
The purpose of this pull request is to populate the [TeamCity default statistics values](https://confluence.jetbrains.com/display/TCD9/Custom+Chart#CustomChart-listOfDefaultStatisticValues) with the matching coverage statistics.

This leverages the built in TeamCity statistics for coverage and eliminates the need to create custom statistics.

![codecoveragesummary](https://user-images.githubusercontent.com/2163396/35119085-1b67d840-fc51-11e7-9a6a-8fad4c7367fe.PNG)
![codecoveragestatistics](https://user-images.githubusercontent.com/2163396/35119095-238a8518-fc51-11e7-9193-330e1064c48b.PNG)
