### PR TITLE
flowId added to teamcity logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,22 @@
 var pathSep = require('path').sep;
 var TEAMCITY_VERSION = 'TEAMCITY_VERSION';
 
+const processPID = process.pid.toString();
+
+const TEST_IGNORED = "##teamcity[testIgnored name='%s' message='%s' flowId='%s']";
+const SUITE_START = "##teamcity[testSuiteStarted name='%s' flowId='%s']";
+const SUITE_END = "##teamcity[testSuiteFinished name='%s' duration='%s' flowId='%s']";
+
+const TEST_START = "##teamcity[testStarted name='%s' flowId='%s']";
+const TEST_FAILED = "##teamcity[testFailed name='%s' message='FAILED' details='%s' flowId='%s']";
+const TEST_END = "##teamcity[testFinished name='%s' duration='%s' flowId='%s']";
+
+const BUILD_STATISTIC_VALUE = "##teamcity[buildStatisticValue key='%s' value='%s']";
+
 function teamcityReporter(result) {
     if (TEAMCITY_VERSION in process.env) {
-        result.testResults.forEach(it => logTestSuite(it));
+        var flowId = process.env['JEST_TEAMCITY_FLOWID'] || processPID;
+        result.testResults.forEach(it => logTestSuite(it, flowId));
         if (result.coverageMap != null) {
             logCoverage(result.coverageMap);
         }
@@ -11,43 +24,43 @@ function teamcityReporter(result) {
     return result;
 }
 
-function logTestSuite(suite) {
+function logTestSuite(suite, flowId) {
     const split = suite.testFilePath.split(pathSep);
     const name = escape(split[split.length - 2] + '/' + split[split.length - 1]);
     const duration = suite.perfStats.end - suite.perfStats.start;
     const testResults = suite.testResults;
 
-    console.log("##teamcity[testSuiteStarted name='%s']", name);
+    console.log(SUITE_START, name, flowId);
 
     if (testResults != null && testResults.length > 0) {
-        testResults.forEach(it => logTestResult(suite, it));
+        testResults.forEach(it => logTestResult(suite, it, flowId));
     } else if (suite.failureMessage != null && suite.failureMessage.length > 0) {
-        console.log("##teamcity[testStarted name='Generic test suite failure']");
-        console.log("##teamcity[testFailed name='Generic test suite failure' message='FAILED' details='%s']", escape(suite.failureMessage));
-        console.log("##teamcity[testFinished name='Generic test suite failure' duration='0']");
+        console.log(TEST_START, 'Generic test suite failure', flowId);
+        console.log(TEST_FAILED, 'Generic test suite failure', escape(suite.failureMessage), flowId);
+        console.log(TEST_END, 'Generic test suite failure', '0', flowId);
     }
 
-    console.log("##teamcity[testSuiteFinished name='%s' duration='%s']", name, duration);
+    console.log(SUITE_END, name, duration, flowId);
 }
 
-function logTestResult(suite, testResult) {
+function logTestResult(suite, testResult, flowId) {
     const name = escape(testResult.fullName);
     const duration = testResult.duration;
 
-    console.log("##teamcity[testStarted name='%s']", name);
+    console.log(TEST_START, name, flowId);
 
     if (testResult.status === 'failed') {
         const details = testResult.failureMessages.length > 0
             ? testResult.failureMessages[0]
             : 'No details available';
-        console.log("##teamcity[testFailed name='%s' message='FAILED' details='%s']", name, escape(details));
+        console.log(TEST_FAILED, name, escape(details), flowId);
     }
 
     if (testResult.status === 'pending' || testResult.status === 'skipped') {
-        console.log("##teamcity[testIgnored name='%s' message='%s']", name, testResult.status);
+        console.log(TEST_IGNORED, name, testResult.status, flowId);
     }
 
-    console.log("##teamcity[testFinished name='%s' duration='%s']", name, duration);
+    console.log(TEST_END, name, duration, flowId);
 }
 
 function logCoverage(coverageMap) {
@@ -67,14 +80,14 @@ function logCoverage(coverageMap) {
                 'Statements': 'S'
             };
             
-            console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Total Number of JS ${key}`, metrics.total);
-            console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Covered Number of JS ${key}`, metrics.covered);
-            console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `Covered Percentage of JS ${key}`, metrics.pct);
+            console.log(BUILD_STATISTIC_VALUE, `Total Number of JS ${key}`, metrics.total);
+            console.log(BUILD_STATISTIC_VALUE, `Covered Number of JS ${key}`, metrics.covered);
+            console.log(BUILD_STATISTIC_VALUE, `Covered Percentage of JS ${key}`, metrics.pct);
             
             if(tcKeyDict[key]) {
                 const tcKey = tcKeyDict[key];
-                console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoverageAbs${tcKey}Total`, metrics.total);
-                console.log("##teamcity[buildStatisticValue key='%s' value='%s']", `CodeCoverageAbs${tcKey}Covered`, metrics.covered);
+                console.log(BUILD_STATISTIC_VALUE, `CodeCoverageAbs${tcKey}Total`, metrics.total);
+                console.log(BUILD_STATISTIC_VALUE, `CodeCoverageAbs${tcKey}Covered`, metrics.covered);
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-teamcity-reporter",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "license": "MIT",
   "description": "Teamcity Reporter for Jest Test Results",
   "homepage": "https://github.com/winterbe/jest-teamcity-reporter",


### PR DESCRIPTION
https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html#BuildScriptInteractionwithTeamCity-ReportingTests

https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html#Message-FlowId

When running tests inside a container (docker 19.03) on TeamCity agent (VM - ubuntu 18.04)
teamcity treats tests as failed. adding flowId helps to solve this issue.